### PR TITLE
Fix name of x86_64 arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ var installer = require('electron-installer-flatpak')
 var options = {
   src: 'dist/app-linux-x64/',
   dest: 'dist/installers/',
-  arch: 'amd64'
+  arch: 'x86_64'
 }
 
 console.log('Creating package (this may take a while)')

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "exe32": "electron-packager . poopie --platform linux --arch ia32 --out dist/ --ignore \"(dist|node_modules/electron.*)\"",
     "exe64": "electron-packager . poopie --platform linux --arch x64 --out dist/ --ignore \"(dist|node_modules/electron.*)\"",
     "flatpak32": "electron-installer-flatpak --src dist/poopie-linux-ia32/ --arch i386 --config config.json",
-    "flatpak64": "electron-installer-flatpak --src dist/poopie-linux-x64/ --arch amd64 --config config.json",
+    "flatpak64": "electron-installer-flatpak --src dist/poopie-linux-x64/ --arch x86_64 --config config.json",
     "build": "npm run clean && npm run exe32 && npm run flatpak32 && npm run exe64 && npm run flatpak64"
   },
   "devDependencies": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -34,12 +34,12 @@ describe('cli', function () {
       spawn('node src/cli.js', [
         '--src', 'test/fixtures/app-without-asar/',
         '--dest', dest,
-        '--arch', 'amd64'
+        '--arch', 'x86_64'
       ], done)
     })
 
     it('generates a `.flatpak` package', function (done) {
-      access(dest + 'com.foo.bartest_master_amd64.flatpak', done)
+      access(dest + 'com.foo.bartest_master_x86_64.flatpak', done)
     })
   })
 })

--- a/test/installer.js
+++ b/test/installer.js
@@ -46,7 +46,7 @@ describe('module', function () {
           bin: 'resources/cli/bar.sh',
           section: 'devel',
           priority: 'optional',
-          arch: 'amd64'
+          arch: 'x86_64'
         }
       }, done)
     })
@@ -56,7 +56,7 @@ describe('module', function () {
     })
 
     it('generates a `.flatpak` package', function (done) {
-      access(dest + 'com.foo.bartest_master_amd64.flatpak', done)
+      access(dest + 'com.foo.bartest_master_x86_64.flatpak', done)
     })
   })
 })


### PR DESCRIPTION
Flatpak files/repos use `x86_64` to denote 64-bit x86 architectures. I assume all of the `amd64` references were left over from `electron-installer-debian`.

It was mostly kind of odd seeing `amd64` in one place in the readme, and `x86_64` in another place.