### PR TITLE
Use node style arches everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ $ npm install -g electron-installer-flatpak
 And point it to your built app:
 
 ```
-$ electron-installer-flatpak --src dist/app-linux-x64/ --dest dist/installers/ --arch x86_64
+$ electron-installer-flatpak --src dist/app-linux-x64/ --dest dist/installers/ --arch x64
 ```
 
-You'll end up with the package at `dist/installers/app_0.0.1_x86_64.flatpak`.
+You'll end up with the package at `dist/installers/app_0.0.1_x64.flatpak`.
 
 ### Scripts
 
@@ -111,8 +111,8 @@ Edit the `scripts` section of your `package.json`:
   "version": "0.0.1",
   "scripts": {
     "start": "electron .",
-    "build": "electron-packager . app --platform linux --arch x86_64 --out dist/",
-    "flatpak64": "electron-installer-flatpak --src dist/app-linux-x64/ --dest dist/installers/ --arch x86_64"
+    "build": "electron-packager . app --platform linux --arch x64 --out dist/",
+    "flatpak64": "electron-installer-flatpak --src dist/app-linux-x64/ --dest dist/installers/ --arch x64"
   },
   "devDependencies": {
     "electron-installer-flatpak": "*",
@@ -128,7 +128,7 @@ And run the script:
 $ npm run flatpak64
 ```
 
-You'll end up with the package at `dist/installers/app_0.0.1_x86_64.flatpak`.
+You'll end up with the package at `dist/installers/app_0.0.1_x64.flatpak`.
 
 ### Programmatically
 
@@ -146,7 +146,7 @@ var installer = require('electron-installer-flatpak')
 var options = {
   src: 'dist/app-linux-x64/',
   dest: 'dist/installers/',
-  arch: 'amd64'
+  arch: 'x64'
 }
 
 console.log('Creating package (this may take a while)')
@@ -161,7 +161,7 @@ installer(options, function (err) {
 })
 ```
 
-You'll end up with the package at `dist/installers/app_0.0.1_x86_64.flatpak`.
+You'll end up with the package at `dist/installers/app_0.0.1_x64.flatpak`.
 
 ### Options
 
@@ -180,7 +180,7 @@ Even though you can pass most of these options through the command-line interfac
 And pass that instead with the `config` option:
 
 ```
-$ electron-installer-flatpak --src dist/app-linux-x64/ --arch x86_64 --config config.json
+$ electron-installer-flatpak --src dist/app-linux-x64/ --arch x64 --config config.json
 ```
 
 Anyways, here's the full list of options:
@@ -274,7 +274,10 @@ Sdk id, used in the [`sdk` field of a flatpak-builder manifest](http://flatpak.o
 Type: `String`
 Default: `undefined`
 
-Machine architecture the package is targeted to.
+Machine architecture the package is targeted to. Suggested to use node style
+arches here ('ia32', 'x64'), which will be converted to flatpak style arches
+('i386', 'x86_64') when calling into the actual flatpak commands. Directly
+using flatpak style arches is also supported.
 
 #### options.finishArgs
 Type: `Array[String]`

--- a/example/package.json
+++ b/example/package.json
@@ -14,8 +14,8 @@
     "start": "electron .",
     "exe32": "electron-packager . poopie --platform linux --arch ia32 --out dist/ --ignore \"(dist|node_modules/electron.*)\"",
     "exe64": "electron-packager . poopie --platform linux --arch x64 --out dist/ --ignore \"(dist|node_modules/electron.*)\"",
-    "flatpak32": "electron-installer-flatpak --src dist/poopie-linux-ia32/ --arch i386 --config config.json",
-    "flatpak64": "electron-installer-flatpak --src dist/poopie-linux-x64/ --arch amd64 --config config.json",
+    "flatpak32": "electron-installer-flatpak --src dist/poopie-linux-ia32/ --arch ia32 --config config.json",
+    "flatpak64": "electron-installer-flatpak --src dist/poopie-linux-x64/ --arch x64 --config config.json",
     "build": "npm run clean && npm run exe32 && npm run flatpak32 && npm run exe64 && npm run flatpak64"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,7 +25,7 @@ var argv = yargs
     describe: 'JSON file that contains the metadata for your application',
     config: true
   })
-  .example('$0 --src dist/app/ --dest dist/installer/ --arch i386', 'use metadata from `dist/app/`')
+  .example('$0 --src dist/app/ --dest dist/installer/ --arch ia32', 'use metadata from `dist/app/`')
   .example('$0 --src dist/app/ --dest dist/installer/ --config config.json', 'use metadata from `config.json`')
   .wrap(null)
   .argv

--- a/test/cli.js
+++ b/test/cli.js
@@ -14,7 +14,7 @@ describe('cli', function () {
       spawn('./src/cli.js', [
         '--src', 'test/fixtures/app-with-asar/',
         '--dest', dest,
-        '--arch', 'i386'
+        '--arch', 'ia32'
       ], done)
     })
 
@@ -23,7 +23,7 @@ describe('cli', function () {
     })
 
     it('generates a `.flatpak` package', function (done) {
-      access(dest + 'io.atom.electron.footest_master_i386.flatpak', done)
+      access(dest + 'io.atom.electron.footest_master_ia32.flatpak', done)
     })
   })
 
@@ -34,12 +34,12 @@ describe('cli', function () {
       spawn('node src/cli.js', [
         '--src', 'test/fixtures/app-without-asar/',
         '--dest', dest,
-        '--arch', 'amd64'
+        '--arch', 'x64'
       ], done)
     })
 
     it('generates a `.flatpak` package', function (done) {
-      access(dest + 'com.foo.bartest_master_amd64.flatpak', done)
+      access(dest + 'com.foo.bartest_master_x64.flatpak', done)
     })
   })
 })

--- a/test/installer.js
+++ b/test/installer.js
@@ -17,7 +17,7 @@ describe('module', function () {
         dest: dest,
 
         options: {
-          arch: 'i386'
+          arch: 'ia32'
         }
       }, done)
     })
@@ -27,7 +27,7 @@ describe('module', function () {
     })
 
     it('generates a `.flatpak` package', function (done) {
-      access(dest + 'io.atom.electron.footest_master_i386.flatpak', done)
+      access(dest + 'io.atom.electron.footest_master_ia32.flatpak', done)
     })
   })
 
@@ -46,7 +46,7 @@ describe('module', function () {
           bin: 'resources/cli/bar.sh',
           section: 'devel',
           priority: 'optional',
-          arch: 'amd64'
+          arch: 'x64'
         }
       }, done)
     })
@@ -56,7 +56,7 @@ describe('module', function () {
     })
 
     it('generates a `.flatpak` package', function (done) {
-      access(dest + 'com.foo.bartest_master_amd64.flatpak', done)
+      access(dest + 'com.foo.bartest_master_x64.flatpak', done)
     })
   })
 })


### PR DESCRIPTION
flatpak-bunder will handle converting from node style arches to
flatpak style arches. Let's be consistent in documenting and testing
with node style arches here. That will match what we are doing
in the companion grunt-electron-installer-flatpak project.