### PR TITLE
installer: add modules option

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,33 @@ Arguments to use when call `flatpak build-finish`, use in the [`finish-args` fie
 
 Changing this can be used to customize permissions of the sandbox the flatpak will run in.
 
+#### options.modules
+Type: `Array[Object]`
+Default: `[]`
+
+This option can be used to build extra software modules into the flatpak
+application sandbox. Most electron applications will not need this, but if you
+are using native node modules that require certain libraries on the system, this
+may be necessary. For example, to build [libgit2](https://libgit2.github.com/)
+to use with [nodegit](https://github.com/nodegit/nodegit), add the following to
+your modules list.
+```
+modules: [
+  {
+    name: 'libgit2',
+    cmake: true,
+    configOpts: [ '-DBUILD_SHARED_LIBS:BOOL=ON', '-DTHREADSAFE=ON' ],
+    sources: [{
+      type: 'git',
+      url: 'https://github.com/libgit2/libgit2.git',
+      branch: 'maint/v0.24'
+    }]
+  }
+]
+```
+
+See the [`modules` field of a flatpak-builder manifest](http://flatpak.org/flatpak/flatpak-docs.html#flatpak-builder) for more details.
+
 #### options.bin
 Type: `String`
 Default: `package.name`

--- a/src/installer.js
+++ b/src/installer.js
@@ -110,6 +110,7 @@ var getDefaults = function (data, callback) {
         // System notifications with libnotify
         '--talk-name=org.freedesktop.Notifications'
       ],
+      modules: [],
 
       bin: pkg.name || 'electron',
       icon: path.resolve(__dirname, '../resources/icon.png'),
@@ -298,7 +299,8 @@ var createBundle = function (options, dir, callback) {
     symlinks: [
       [path.join('/lib', options.id, options.bin), path.join('/bin', options.bin)]
     ],
-    extraExports: extraExports
+    extraExports: extraExports,
+    modules: options.modules
   }, {
     arch: options.arch,
     bundlePath: dest


### PR DESCRIPTION
This will allow projects based off of electron-installer-flatpak
to build extra native libraries into their apps if required.
https://phabricator.endlessm.com/T15119