### PR TITLE
Deal with license files that aren't just named LICENSE

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -74,6 +74,17 @@ var readMeta = function (options, callback) {
  */
 var readLicense = function (options, callback) {
   var licenseSrc = path.join(options.src, 'LICENSE')
+  try {
+    fs.accessSync(licenseSrc)
+  } catch (err) {
+    try {
+      licenseSrc = path.join(options.src, 'LICENSE.txt')
+      fs.accessSync(licenseSrc)
+    } catch (err) {
+      licenseSrc = path.join(options.src, 'LICENSE.md')
+      fs.accessSync(licenseSrc)
+    }
+  }
   options.logger('Reading license file from ' + licenseSrc)
 
   fs.readFile(licenseSrc, callback)


### PR DESCRIPTION
At least Mattermost uses LICENSE.txt. I'm also adding LICENSE.md for
good measure, but it might make sense to also fallback to COPYING (with
the appropriate suffixes) in the future.

Making this more generic seemed involved, so going with the simpler
solution for now.