### PR TITLE
Upgrade asar to ^1.0.0 to remove security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "npm run clean && npm run lint && npm run spec"
   },
   "dependencies": {
-    "asar": "^0.12.0",
+    "asar": "^1.0.0",
     "async": "^2.0.0",
     "debug": "^2.2.0",
     "flatpak-bundler": "^0.1.0",


### PR DESCRIPTION
`asar@1.0.0` removes an unmaintained dependency that also had a transitive dependency with a [security vulnerability](https://www.npmjs.com/advisories/777). None of the other changes should be applicable to this module.